### PR TITLE
feat: 포스트 생성 페이지(/create) 추가

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,13 +1,35 @@
 import MainPage from 'pages/MainPage';
+import CreatePostPage from 'pages/CreatePostPage';
+import { initRouter } from 'utils/router';
 
 interface Props {
   target: HTMLDivElement;
 }
 
 class App {
-  mainPage: MainPage;
+  root: HTMLDivElement;
   constructor({ target }: Props) {
-    this.mainPage = new MainPage({ target });
+    this.root = target;
+    this.route();
+    initRouter(this.route.bind(this));
+  }
+
+  route() {
+    this.root.innerHTML = '';
+    const { pathname } = window.location;
+
+    switch (pathname) {
+      case '/':
+        new MainPage({ target: this.root });
+        break;
+
+      case '/create':
+        new CreatePostPage({ target: this.root });
+        break;
+
+      default:
+        return;
+    }
   }
 }
 

--- a/src/components/MessageList.ts
+++ b/src/components/MessageList.ts
@@ -1,11 +1,4 @@
-export interface Post {
-  postId: string;
-  title: string;
-  content: string;
-  image: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { Post } from 'utils/type';
 
 interface Props {
   target: HTMLElement;

--- a/src/pages/CreatePostPage.ts
+++ b/src/pages/CreatePostPage.ts
@@ -1,0 +1,104 @@
+import { createPost, getRandomImage } from 'utils/api';
+import { replace } from 'utils/router';
+
+interface Props {
+  target: HTMLElement;
+}
+
+interface State {
+  title: string;
+  content: string;
+}
+
+class CreatePostPage {
+  state: State;
+  component: HTMLFormElement;
+  image: string;
+  constructor({ target }: Props) {
+    this.state = {
+      title: '',
+      content: '',
+    };
+
+    this.component = document.createElement('form');
+    target.insertAdjacentElement('beforeend', this.component);
+
+    this.getRandomImage();
+    this.render();
+    this.addHandleChangeEvent();
+  }
+
+  render() {
+    this.component.innerHTML = `
+      <label for="title">제목</label>
+      <input id="CreatePost__Title" name="title" type="text">
+      <label for="content">내용</label>
+      <input id="CreatePost__Content" name="content" type="text">
+      <button id="CreatePost__Submit" type="submit">등록하기</button>
+    `;
+  }
+
+  addHandleChangeEvent() {
+    const titleElement = document.querySelector('#CreatePost__Title');
+    const contentElement = document.querySelector('#CreatePost__Content');
+    const submitButtonElement = document.querySelector('#CreatePost__Submit');
+
+    if (!titleElement || !contentElement || !submitButtonElement) {
+      return;
+    }
+
+    titleElement.addEventListener('input', this.onChange.bind(this));
+    contentElement.addEventListener('input', this.onChange.bind(this));
+    submitButtonElement.addEventListener('submit', this.onSubmit.bind(this));
+    this.component.addEventListener('submit', this.onSubmit.bind(this));
+  }
+
+  setState(nextState: State) {
+    this.state = nextState;
+  }
+
+  onChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    if (!target) {
+      return;
+    }
+
+    this.setState({
+      ...this.state,
+      [target.name]: target.value,
+    });
+  }
+
+  async onSubmit(e: Event) {
+    e.preventDefault();
+    if (this.state.title === '' || this.state.content === '') {
+      return;
+    }
+
+    const response = await createPost({
+      ...this.state,
+      image: this.image,
+    });
+
+    console.log({
+      ...this.state,
+      image: this.image,
+    });
+    console.log(response);
+
+    if (!response) {
+      return;
+    }
+
+    replace('/');
+    return;
+  }
+
+  async getRandomImage() {
+    const randomImage = await getRandomImage();
+    const image = randomImage.urls.small;
+    this.image = image;
+  }
+}
+
+export default CreatePostPage;

--- a/src/pages/MainPage.ts
+++ b/src/pages/MainPage.ts
@@ -1,5 +1,6 @@
-import MessageList, { Post } from 'components/MessageList';
-import { request } from 'utils/api';
+import MessageList from 'components/MessageList';
+import { getPosts } from 'utils/api';
+import type { Post } from 'utils/type';
 
 interface Props {
   target: HTMLElement;
@@ -35,10 +36,7 @@ class MainPage {
   }
 
   async fetchMessageData() {
-    const response = await request<{
-      code: number;
-      data: { posts: Post[] };
-    }>('/posts');
+    const response = await getPosts();
 
     if (!response) {
       return;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,11 +1,24 @@
+import type { Post, PostDetail } from 'utils/type';
+
 const API_END_POINT = process.env.API_END_POINT;
+const UNSPLASH_URL = 'https://api.unsplash.com';
+
+const unsplashFetchOption = {
+  headers: {
+    authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}`,
+  },
+};
 
 export const request = async <T>(
   url: string,
-  option?: RequestInit
+  option?: RequestInit,
+  endPintUrl?: string
 ): Promise<T | undefined> => {
   try {
-    const response = await fetch(`${API_END_POINT}${url}`, option);
+    const response = await fetch(
+      `${endPintUrl ?? API_END_POINT}${url}`,
+      option
+    );
 
     if (!response.ok) {
       throw new Error(
@@ -17,4 +30,38 @@ export const request = async <T>(
   } catch (e) {
     console.error(e);
   }
+};
+
+export const getPosts = async () => {
+  return await request<{
+    code: number;
+    data: { posts: Post[] };
+  }>('/posts');
+};
+
+export const getRandomImage = async () => {
+  return await request<{ urls: { small: string } }>(
+    '/photos/random',
+    unsplashFetchOption,
+    UNSPLASH_URL
+  );
+};
+
+export const createPost = async (body: {
+  title: string;
+  content: string;
+  image: string;
+}) => {
+  return await request<{
+    code: number;
+    data: {
+      post: PostDetail;
+    };
+  }>('/post', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 };

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -1,0 +1,56 @@
+interface PushEvent extends Event {
+  detail: {
+    url: string;
+  };
+}
+
+const ROUTE_PUSH = 'ROUTE_PUSH';
+const ROUTE_REPLACE = 'ROUTE_REPLACE';
+
+export const initRouter = <T extends () => void>(callback: T) => {
+  window.addEventListener(ROUTE_PUSH, ((e: PushEvent) => {
+    const url = e.detail?.url;
+
+    if (!url) {
+      return;
+    }
+
+    history.pushState(null, '', url);
+    callback();
+  }) as EventListener);
+
+  window.addEventListener(ROUTE_REPLACE, ((e: PushEvent) => {
+    const url = e.detail?.url;
+
+    if (!url) {
+      return;
+    }
+
+    history.replaceState(null, '', url);
+    callback();
+  }) as EventListener);
+
+  window.addEventListener('popstate', () => {
+    callback();
+  });
+};
+
+export const push = (url: string) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_PUSH, {
+      detail: {
+        url,
+      },
+    })
+  );
+};
+
+export const replace = (url: string) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_REPLACE, {
+      detail: {
+        url,
+      },
+    })
+  );
+};

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,0 +1,17 @@
+export interface Post {
+  postId: string;
+  title: string;
+  content: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PostDetail {
+  postId: string;
+  title: string;
+  content: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,8 @@ const dotenv = require('dotenv').config({
   path: path.resolve(__dirname, '.env'),
 });
 
+console.log(dotenv);
+
 module.exports = {
   entry: './src/index.ts',
   mode: 'development',
@@ -68,5 +70,8 @@ module.exports = {
     },
     open: true,
     port: 'auto',
+    historyApiFallback: {
+      index: 'index.html',
+    },
   },
 };


### PR DESCRIPTION
## 변경사항
- Router 추가 후 MainPage('/'), CreatePostPage('/create') 페이지 분리
- push, replace 메서드 추가
- CreatePostPage 추가

## TODO

- 스타일링
- 나머지 API 추가
- Post 상세 페이지 추가

## 진행상황
![image](https://user-images.githubusercontent.com/85148549/212695261-41b4f836-ae88-4034-8419-58b583ce1490.png)
- 이미지는 페이지 진입 시 미리 받아오고, Submit할 때 이미지 사용 (Unsplash API Demo 버전 get 제한 관련)
- 스타일링 없이 제목, 내용만 사용

